### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/keving2105/3d917ebf-3529-40c1-82bb-2209b58067f8/7345e44d-f3b2-4a70-81e3-90b585a52316/_apis/work/boardbadge/c643bc42-87a1-48f8-a341-059331a238bc)](https://dev.azure.com/keving2105/3d917ebf-3529-40c1-82bb-2209b58067f8/_boards/board/t/7345e44d-f3b2-4a70-81e3-90b585a52316/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/keving2105/3d917ebf-3529-40c1-82bb-2209b58067f8/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.